### PR TITLE
Use esling-plugin-import

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "babel-eslint": "7.1.0",
     "eslint": "=3.10.0",
+    "eslint-plugin-import": "=2.2.0",
     "eslint-plugin-react": "=6.6.0",
     "eslint-plugin-react-native": "=2.0.0"
   }

--- a/react/.eslintrc
+++ b/react/.eslintrc
@@ -12,6 +12,7 @@
   },
   "plugins": [
     "react",
+    "import"
   ],
   "rules": {
     "jsx-quotes": [2, "prefer-double"],


### PR DESCRIPTION
> This plugin intends to support linting of ES2015+ (ES6+) import/export syntax, and prevent issues with misspelling of file paths and import names.

More information: https://www.npmjs.com/package/eslint-plugin-import