### PR TITLE
Indent and eslint dep

### DIFF
--- a/base/.eslintrc.json
+++ b/base/.eslintrc.json
@@ -3,7 +3,7 @@
     "strict": [2, "global"],
     "comma-style": 2,
     "comma-spacing": 2,
-    "indent": [2, 2, { "SwitchCase": 1, "outerIIFEBody": 1, "MemberExpression": 1 }],
+    "indent": [2, 2, { "SwitchCase": 1, "outerIIFEBody": 1, "MemberExpression": 1, "ArrayExpression": 1, "ObjectExpression": 1 }],
     "quotes": [2, "single"],
     "linebreak-style": 2,
     "semi": [2, "always"],

--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
     "jsonlint": "=1.6.2"
   },
   "peerDependencies": {
-    "eslint": "=3.19.0"
+    "eslint": ">=3.12.x <4.x.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "eslint-plugin-react-native": "=2.0.0"
   },
   "devDependencies": {
+    "eslint": "=3.19.0",
     "jsonlint": "=1.6.2"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-dabapps",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "DabApps ESLint Configuration",
   "main": ".eslintrc.json",
   "scripts": {


### PR DESCRIPTION
* Fix / make dependencies more flexible
* Additional indentation rules

The dev dependency on eslint is required for running the tests, as peer dependencies are not installed in dev.

Allowed us to adjust the version of eslint we are using within compatible bounds (new rules require at least `3.12`, but `4` would make breaking changes).