### PR TITLE
Translate tslint import/order rules into eslint

### DIFF
--- a/base/.eslintrc.json
+++ b/base/.eslintrc.json
@@ -49,7 +49,7 @@
       }
     ],
     "import/order": [
-      1,
+      2,
       {
         "newlines-between": "always",
         "groups": [

--- a/base/.eslintrc.json
+++ b/base/.eslintrc.json
@@ -52,31 +52,15 @@
       1,
       {
         "newlines-between": "always",
+        "groups": [
+          ["builtin", "external"],
+          ["internal", "parent", "sibling", "index"],
+          ["unknown"]
+        ],
         "pathGroups": [
           {
-            "group": "builtin",
-            "pattern": "^[@a-zA-Z]",
-            "position": "before"
-          },
-          {
-            "group": "external",
-            "pattern": "^[@a-zA-Z]",
-            "position": "before"
-          },
-          {
             "group": "internal",
-            "pattern": "^[^@a-zA-Z]",
-            "position": "after"
-          },
-          {
-            "group": "parent",
-            "pattern": "^[^@a-zA-Z]",
-            "position": "after"
-          },
-          {
-            "group": "sibling",
-            "pattern": "*",
-            "position": "after"
+            "pattern": "^"
           }
         ]
       }

--- a/base/.eslintrc.json
+++ b/base/.eslintrc.json
@@ -48,6 +48,40 @@
         "allow": ["^UNSAFE_"]
       }
     ],
+    "import/order": [
+      1,
+      {
+        "newlines-between": "always",
+        "pathGroups": [
+          {
+            "group": "builtin",
+            "pattern": "^[@a-zA-Z]",
+            "position": "before"
+          },
+          {
+            "group": "external",
+            "pattern": "^[@a-zA-Z]",
+            "position": "before"
+          },
+          {
+            "group": "internal",
+            "pattern": "^[^@a-zA-Z]",
+            "position": "after"
+          },
+          {
+            "group": "parent",
+            "pattern": "^[^@a-zA-Z]",
+            "position": "after"
+          },
+          {
+            "group": "sibling",
+            "pattern": "*",
+            "position": "after"
+          }
+        ]
+      }
+    ],
+    "import/no-relative-parent-imports": 2,
     "import/no-unresolved": [
       2,
       {

--- a/base/.eslintrc.json
+++ b/base/.eslintrc.json
@@ -60,7 +60,7 @@
         "pathGroups": [
           {
             "group": "internal",
-            "pattern": "^"
+            "pattern": "^/**"
           }
         ]
       }

--- a/base/.eslintrc.json
+++ b/base/.eslintrc.json
@@ -65,7 +65,6 @@
         ]
       }
     ],
-    "import/no-relative-parent-imports": 2,
     "import/no-unresolved": [
       2,
       {

--- a/test-files/imports-fail.js
+++ b/test-files/imports-fail.js
@@ -2,7 +2,6 @@ import React from 'react';
 import Dom from 'react-dom';
 
 import nooo from '../base/test';
-
 import { foo as fu } from './js-fail';
 import { baz as bart } from './imports-pass';
 

--- a/test-files/imports-fail.js
+++ b/test-files/imports-fail.js
@@ -1,3 +1,13 @@
+import React from 'react';
+import Dom from 'react-dom';
+
+import nooo from '../base/test';
+
+import { foo as fu } from './js-fail';
+import { baz as bart } from './imports-pass';
+
+import yaaaaa from '^/base/test-copy';
+
 export const foo = 'bar';
 export const baz = 'foo';
 

--- a/test-files/js-fail.js
+++ b/test-files/js-fail.js
@@ -1,6 +1,7 @@
 import $ from 'jquery';
 import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
+
 import foo from './imports-pass';
 import { maFunction } from './ts-pass';
 

--- a/test-files/tsx-pass.tsx
+++ b/test-files/tsx-pass.tsx
@@ -1,6 +1,7 @@
 import $ from 'jquery';
 import React, { ReactNode } from 'react';
 import ReactDOM from 'react-dom';
+
 import { StateProps } from './ts-fail';
 
 const _LEADING_UNDERSCORE = 'Title';


### PR DESCRIPTION
TSLINT missing rules (import order)

* Added config matching our tslint config
* Remove parent relative import rule (didn't work as intended)

```
    "ordered-imports": [
      true,
      {
        "grouped-imports": true,
        "groups": [
          {
            "name": "node modules",
            "match": "^[@a-zA-Z]",
            "order": 0
          },
          {
            "name": "local modules",
            "match": "^[^@a-zA-Z]",
            "order": 1
          },
          {
            "name": "unknown",
            "match": null,
            "order": 2
          }
        ]
      }
    ],
```