### PR TITLE
Remove max-lines rule

### DIFF
--- a/base/.eslintrc.json
+++ b/base/.eslintrc.json
@@ -38,7 +38,6 @@
     "no-fallthrough": 2,
     "default-case": 2,
 
-    "max-lines": [2, { "max": 120 }],
     "no-var": 2,
     "no-unused-expressions": 2,
     "camelcase": [


### PR DESCRIPTION
We've never previously had this as a rule, it must have been added by mistake (confusion with `max-len` which we also no longer use because prettier manages this).