### PR TITLE
Apply no-relative-parent-import to only es and ts modules

### DIFF
--- a/base/.eslintrc.json
+++ b/base/.eslintrc.json
@@ -111,7 +111,6 @@
         "allowLiteral": false,
         "allowObject": false
       }
-    ],
-    "dabapps/no-relative-parent-import": 2
+    ]
   }
 }

--- a/es/.eslintrc.json
+++ b/es/.eslintrc.json
@@ -15,6 +15,7 @@
     "import/resolver": "webpack"
   },
   "rules": {
-    "no-var": 2
+    "no-var": 2,
+    "dabapps/no-relative-parent-import": 2
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-dabapps",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-dabapps",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "DabApps ESLint Configuration",
   "main": ".eslintrc.json",
   "scripts": {

--- a/typescript/.eslintrc.json
+++ b/typescript/.eslintrc.json
@@ -18,6 +18,7 @@
     "@typescript-eslint/type-annotation-spacing": 0,
     "@typescript-eslint/no-unused-vars": 2,
     "import/named": 0,
-    "react/sort-comp": 0
+    "react/sort-comp": 0,
+    "dabapps/no-relative-parent-import": 2
   }
 }


### PR DESCRIPTION
Some older projects will not have our absolute import alias, so we should only enable this for ES and TS projects.
Going to bump to `6.0.2` after review.