### PR TITLE
TypeScript overrides

### DIFF
--- a/base/.eslintrc.json
+++ b/base/.eslintrc.json
@@ -111,6 +111,7 @@
         "allowLiteral": false,
         "allowObject": false
       }
-    ]
+    ],
+    "import/named": 2
   }
 }

--- a/typescript/.eslintrc.json
+++ b/typescript/.eslintrc.json
@@ -17,8 +17,15 @@
     "@typescript-eslint/member-delimiter-style": 0,
     "@typescript-eslint/type-annotation-spacing": 0,
     "@typescript-eslint/no-unused-vars": 2,
-    "import/named": 0,
-    "react/sort-comp": 0,
     "dabapps/no-relative-parent-import": 2
-  }
+  },
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {
+        "import/named": 0,
+        "react/sort-comp": 0
+      }
+    }
+  ]
 }


### PR DESCRIPTION
This allows these rules to apply to non-ts files. Tested locally on a JS project and it is now working.
I just hope it works on TS projects (should do if the documentation was correct).