### PR TITLE
Disable annoying rules

### DIFF
--- a/base/.eslintrc.json
+++ b/base/.eslintrc.json
@@ -40,13 +40,7 @@
 
     "no-var": 2,
     "no-unused-expressions": 2,
-    "camelcase": [
-      2,
-      {
-        "properties": "always",
-        "allow": ["^UNSAFE_"]
-      }
-    ],
+    "camelcase": 0,
     "import/order": [
       2,
       {

--- a/base/.eslintrc.json
+++ b/base/.eslintrc.json
@@ -93,7 +93,7 @@
         "tsx": "never"
       }
     ],
-    "import/prefer-default-export": 2,
+    "import/prefer-default-export": 0,
     "import/no-anonymous-default-export": [
       2,
       {

--- a/base/.eslintrc.json
+++ b/base/.eslintrc.json
@@ -76,7 +76,8 @@
     "import/no-unused-modules": [
       2,
       {
-        "unusedExports": true
+        "unusedExports": false,
+        "missingExports": true
       }
     ],
     "import/no-deprecated": 2,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-dabapps",
-  "version": "6.0.4",
+  "version": "6.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-dabapps",
-  "version": "6.0.4",
+  "version": "6.1.0",
   "description": "DabApps ESLint Configuration",
   "main": ".eslintrc.json",
   "scripts": {


### PR DESCRIPTION
`camelcase` - we all know javascript is camelcase, but this is real annoying for request data.
`import/prefer-default-export` - this is good for React components, but annoying for everything else (every time you create a new actions, reducers, utils, constants file that only has one export, even though they will eventually have more).
`import/no-unused-modules` - this is incredibly useful for finding dead code, but it's annoying when you export types for future use. I suggest we just enable this fro time to time.

For `import/no-unused-modules` I have disabled `unusedExports`, allowing us to export types, etc, but enabled `missingExports` which will highlight files that don't have any exports.

This will mean that any entry files will need an ignore statement at the top:

```
// eslint-disable import/no-unused-modules
```