### PR TITLE
Disable no unused modules

### DIFF
--- a/base/.eslintrc.json
+++ b/base/.eslintrc.json
@@ -73,13 +73,7 @@
         "noUselessIndex": true
       }
     ],
-    "import/no-unused-modules": [
-      2,
-      {
-        "unusedExports": false,
-        "missingExports": true
-      }
-    ],
+    "import/no-unused-modules": 0,
     "import/no-deprecated": 2,
     "import/no-extraneous-dependencies": 2,
     "import/no-mutable-exports": 2,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-dabapps",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-dabapps",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "description": "DabApps ESLint Configuration",
   "main": ".eslintrc.json",
   "scripts": {

--- a/scripts/test-config
+++ b/scripts/test-config
@@ -1,5 +1,7 @@
 #! /bin/bash
 
+set -e
+
 npx eslint 'test-files/*-pass.{ts,tsx,js,jsx}'
 
 if npx eslint 'test-files/*-fail.{ts,tsx,js,jsx}'; then

--- a/test-files/tsx-pass.tsx
+++ b/test-files/tsx-pass.tsx
@@ -2,13 +2,17 @@ import $ from 'jquery';
 import React, { ReactNode } from 'react';
 import ReactDOM from 'react-dom';
 
-import { StateProps } from './ts-fail';
-
 const _LEADING_UNDERSCORE = 'Title';
 const PascalCaseTitle = _LEADING_UNDERSCORE;
 
 export interface Props {
   greating: string;
+}
+
+export interface StateProps {
+  index: number;
+  arr: Array<string>;
+  obj: Record<string, unknown>;
 }
 
 export interface SomeProps {


### PR DESCRIPTION
Adding `missingExports` caused all test files to fail - very annoying.

Although there is an option to specify files/paths to ignore from this rule, it also fails if it does not find any files matching the supplied files/paths.

The easiest option is just to disable the rule completely.

Also added `set -e` to ensure the test-files actually fail if they fail.