### PR TITLE
Remove webpack as default resolver for typescript

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,11 @@ See https://github.com/benmosher/eslint-plugin-import#resolvers
   "import/resolver": "./my-resolver"
 }
 ```
+
+For instance older projects using webpack should have the following in their `.eslintrc.json` file:
+
+```
+  "settings": {
+    "import/resolver": "webpack"
+  },
+```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ESLint Config
 
-
 ## About
+
 This repository includes a collection of eslint configs that can be combined to lint just about any project, and a default config for all projects that follow our recent patterns.
 
 
@@ -10,17 +10,8 @@ This repository includes a collection of eslint configs that can be combined to 
 Install a specific version of the eslint config with NPM. You can see a full list of versions [here](https://github.com/dabapps/eslint-config-dabapps/releases).
 
 ```shell
-npm i dabapps/eslint-config-dabapps#v3.0.0 --save-dev
+npm install eslint-config-dabapps --save-dev
 ```
-
-This will update your package.json automatically.
-
-```json
-"devDependencies": {
-  "eslint-config-dabapps": "dabapps/eslint-config-dabapps#v3.0.0",
-}
-```
-
 
 ## Configuration
 
@@ -48,7 +39,7 @@ Create an `.eslintrc.json` in the route of the project. For most projects you ca
 }
 ```
 
-Explanation of the default config below
+Explanation of the default config below:
 
 
 ### Custom Config

--- a/typescript/.eslintrc.json
+++ b/typescript/.eslintrc.json
@@ -8,9 +8,6 @@
     "prettier/@typescript-eslint"
   ],
   "plugins": ["@typescript-eslint"],
-  "settings": {
-    "import/resolver": "webpack"
-  },
   "rules": {
     "@typescript-eslint/no-explicit-any": 2,
     "@typescript-eslint/explicit-function-return-type": 0,


### PR DESCRIPTION
This causes issues when projects don't use `webpack`.

If we are planning to move forward with `esbuild` we should stop assuming `webpack` is the default and instead default to the `typescript` resolver - this could be a breaking change so should probably become v9.

Older project using `webpack` should add the line `"import/resolver": "webpack"` to settings in their `.eslint.json` file.