### PR TITLE
9.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "eslint-config-dabapps",
-  "version": "8.0.0",
+  "version": "9.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "8.0.0",
+      "version": "9.0.0",
       "license": "BSD",
       "dependencies": {
         "@babel/core": "^7.13.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-dabapps",
-  "version": "8.0.0",
+  "version": "9.0.0",
   "description": "DabApps ESLint Configuration",
   "main": ".eslintrc.json",
   "scripts": {


### PR DESCRIPTION
Bump to version 9.0.0. Note this is major release as it contains breaking changes.

## This release contains:

https://github.com/dabapps/eslint-config-dabapps/pull/79 
https://github.com/dabapps/eslint-config-dabapps/pull/80

## Release notes
* [Breaking] Webpack is no longer used as the default resolver for typescript. Older projects using webpack should add the line `"import/resolver": "webpack"` to settings in their `.eslint.json` file
* We've remove the `no-relative-parent-import` rule as we've decided that we no longer require absolute paths - these don't play nicely with our new project template or react-native